### PR TITLE
bd - exclude headers option added on file upload

### DIFF
--- a/lib/restclient/payload.rb
+++ b/lib/restclient/payload.rb
@@ -198,7 +198,7 @@ module RestClient
       end
 
       def headers
-        super.merge({'Content-Type' => %Q{multipart/form-data; boundary=--ABW5FxdjB4-3nf6AYqUutk96-trWPzHdLABW5FxdjB4}})
+        super.merge({'Content-Type' => %Q{multipart/form-data; boundary=ABW5FxdjB4-3nf6AYqUutk96-trWPzHdLABW5FxdjB4}})
       end
 
       def close

--- a/lib/restclient/payload.rb
+++ b/lib/restclient/payload.rb
@@ -197,14 +197,8 @@ module RestClient
         key
       end
 
-      def headers(context_type_header)
-=begin
-        context_type = context_type_header.present? ?
-          {'Content-Type' => %Q{#{context_type_header}}} :
-          {'Content-Type' => %Q{multipart/form-data; boundary=ABW5FxdjB4-3nf6AYqUutk96-trWPzHdLABW5FxdjB4}}
-=end
-
-
+      def headers
+        # TODO: Update to allow user to pass in boundary in execute call
         super.merge({'Content-Type' => %Q{multipart/form-data; boundary=ABW5FxdjB4-3nf6AYqUutk96-trWPzHdLABW5FxdjB4}})
       end
 

--- a/lib/restclient/payload.rb
+++ b/lib/restclient/payload.rb
@@ -198,7 +198,7 @@ module RestClient
       end
 
       def headers
-        super.merge({'Content-Type' => %Q{multipart/form-data; boundary=--TestBoundarySetByAdstream}})
+        super.merge({'Content-Type' => %Q{multipart/form-data; boundary=--ABW5FxdjB4-3nf6AYqUutk96-trWPzHdLABW5FxdjB4}})
       end
 
       def close

--- a/lib/restclient/payload.rb
+++ b/lib/restclient/payload.rb
@@ -198,11 +198,14 @@ module RestClient
       end
 
       def headers(context_type_header)
+=begin
         context_type = context_type_header.present? ?
           {'Content-Type' => %Q{#{context_type_header}}} :
           {'Content-Type' => %Q{multipart/form-data; boundary=ABW5FxdjB4-3nf6AYqUutk96-trWPzHdLABW5FxdjB4}}
+=end
 
-        super.merge(context_type)
+
+        super.merge({'Content-Type' => %Q{multipart/form-data; boundary=ABW5FxdjB4-3nf6AYqUutk96-trWPzHdLABW5FxdjB4}})
       end
 
       def close

--- a/lib/restclient/payload.rb
+++ b/lib/restclient/payload.rb
@@ -198,7 +198,7 @@ module RestClient
       end
 
       def headers
-        super.merge({'Content-Type' => %Q{multipart/form-data; boundary=--TestBoundarySetByAdstream})
+        super.merge({'Content-Type' => %Q{multipart/form-data; boundary=--TestBoundarySetByAdstream}})
       end
 
       def close

--- a/lib/restclient/payload.rb
+++ b/lib/restclient/payload.rb
@@ -197,8 +197,12 @@ module RestClient
         key
       end
 
-      def headers
-        super.merge({'Content-Type' => %Q{multipart/form-data; boundary=ABW5FxdjB4-3nf6AYqUutk96-trWPzHdLABW5FxdjB4}})
+      def headers(context_type_header)
+        context_type = context_type_header.present? ?
+          {'Content-Type' => %Q{#{context_type_header}}} :
+          {'Content-Type' => %Q{multipart/form-data; boundary=ABW5FxdjB4-3nf6AYqUutk96-trWPzHdLABW5FxdjB4}}
+
+        super.merge(context_type)
       end
 
       def close

--- a/lib/restclient/payload.rb
+++ b/lib/restclient/payload.rb
@@ -198,7 +198,7 @@ module RestClient
       end
 
       def headers
-        super.merge({'Content-Type' => %Q{multipart/form-data; boundary=#{boundary}}})
+        super.merge({'Content-Type' => %Q{multipart/form-data; boundary=--TestBoundarySetByAdstream})
       end
 
       def close

--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -365,8 +365,7 @@ module RestClient
 
       # override headers from the payload (e.g. Content-Type, Content-Length)
       if @payload
-        puts "The RESTCLIENT headers are...: #{headers}"
-        payload_headers = @payload.headers
+        payload_headers = @payload.headers(headers["Content-Type"])
 
         # Warn the user if we override any headers that were previously
         # present. This usually indicates that rest-client was passed

--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -363,7 +363,6 @@ module RestClient
     def make_headers(user_headers)
       headers = stringify_headers(default_headers).merge(stringify_headers(user_headers))
 
-
       # override headers from the payload (e.g. Content-Type, Content-Length)
       if @payload
         payload_headers = @payload.headers
@@ -383,8 +382,6 @@ module RestClient
 
         headers.merge!(payload_headers)
       end
-
-
 
       # merge in cookies
       cookies = make_cookie_header

--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -363,8 +363,8 @@ module RestClient
     def make_headers(user_headers)
       headers = stringify_headers(default_headers).merge(stringify_headers(user_headers))
 
-=begin
-# override headers from the payload (e.g. Content-Type, Content-Length)
+
+      # override headers from the payload (e.g. Content-Type, Content-Length)
       if @payload
         payload_headers = @payload.headers
 
@@ -383,7 +383,7 @@ module RestClient
 
         headers.merge!(payload_headers)
       end
-=end
+
 
 
       # merge in cookies

--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -365,6 +365,7 @@ module RestClient
 
       # override headers from the payload (e.g. Content-Type, Content-Length)
       if @payload
+        puts "The RESTCLIENT headers are...: #{headers}"
         payload_headers = @payload.headers
 
         # Warn the user if we override any headers that were previously

--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -365,7 +365,7 @@ module RestClient
 
       # override headers from the payload (e.g. Content-Type, Content-Length)
       if @payload
-        payload_headers = @payload.headers(headers["Content-Type"])
+        payload_headers = @payload.headers
 
         # Warn the user if we override any headers that were previously
         # present. This usually indicates that rest-client was passed

--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -363,7 +363,8 @@ module RestClient
     def make_headers(user_headers)
       headers = stringify_headers(default_headers).merge(stringify_headers(user_headers))
 
-      # override headers from the payload (e.g. Content-Type, Content-Length)
+=begin
+# override headers from the payload (e.g. Content-Type, Content-Length)
       if @payload
         payload_headers = @payload.headers
 
@@ -382,6 +383,8 @@ module RestClient
 
         headers.merge!(payload_headers)
       end
+=end
+
 
       # merge in cookies
       cookies = make_cookie_header


### PR DESCRIPTION
Note: branched from payload-boundary branch, merge that first.

* Added an option to pass an `exclude_headers` option into a POST.  This will send a file upload without any boundary string and header info.